### PR TITLE
T1971: Revert "intel: change module installation dir"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,10 +222,7 @@ pipeline {
 
                                 # compile module
                                 cd "${env.WORKSPACE}/${driver_dir}/src"
-                                KSRC="${env.WORKSPACE}/linux-kernel" \
-                                    INSTALL_MOD_PATH="${debian_dir}" \
-                                    INSTALL_MOD_DIR="kernel/drivers/net/ethernet/intel/${driver_name}" \
-                                    make -j \$(getconf _NPROCESSORS_ONLN) install
+                                KSRC="${env.WORKSPACE}/linux-kernel" INSTALL_MOD_PATH="${debian_dir}" make -j \$(getconf _NPROCESSORS_ONLN) install
 
                                 mkdir -p \$(dirname "${deb_control}")
 


### PR DESCRIPTION
This reverts commit f303ecb89f3478f6901a63806d4f8f0af6f169d0.
Replaced by the more universal initramfs-tools hook in vyos-build (https://github.com/vyos/vyos-build/pull/82/)