### PR TITLE
firmware: T1958: only include firmware for compiled Kernel drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /wireguard-linux-compat
 /accel-ppp
 /intel-qat
+/linux-firmware
 /qat*
 *.deb
 *.changes
@@ -15,5 +16,5 @@ igb-*/
 ixgbe-*/
 ixgbevf-*/
 vyos-intel-*/
-
+vyos-linux-firmware*/
 kernel-vars

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,6 +128,18 @@ pipeline {
                         }
                     }
                 }
+                stage('Kernel Firmware') {
+                    steps {
+                        dir('linux-firmware') {
+                            checkout([$class: 'GitSCM',
+                                doGenerateSubmoduleConfigurations: false,
+                                extensions: [[$class: 'CleanCheckout'],
+                                             [$class: 'CloneOption', depth: 1, noTags: false, reference: '', shallow: true]],
+                                branches: [[name: '20191022' ]],
+                                userRemoteConfigs: [[url: 'https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git']]])
+                        }
+                    }
+                }
                 stage('WireGuard') {
                     steps {
                         dir('wireguard') {
@@ -186,9 +198,14 @@ pipeline {
                        sh "./build-accel-ppp.sh"
                     }
                 }
-                stage('Intel-QAT') {
+                stage('Intel QuickAssist Technology') {
                     steps {
                         sh "./build-intel-qat.sh"
+                    }
+                }
+                stage('Linux Firmware') {
+                    steps {
+                        sh "./build-linux-firmware.sh"
                     }
                 }
             }

--- a/build-intel-drivers.sh
+++ b/build-intel-drivers.sh
@@ -77,7 +77,7 @@ EOF
 
     # build Debian package
     echo "I: Building Debian package vyos-intel-${DRIVER_NAME}"
-    dpkg-deb --build ${DEBIAN_DIR}
+    fakeroot dpkg-deb --build ${DEBIAN_DIR}
 
 
     echo "I: Cleanup ${DRIVER_NAME} source"

--- a/build-intel-qat.sh
+++ b/build-intel-qat.sh
@@ -83,17 +83,17 @@ EOF
 
     # build Debian package
     echo "I: Building Debian package vyos-intel-${DRIVER_NAME}"
-    dpkg-deb --build ${DEBIAN_DIR}
+    fakeroot dpkg-deb --build ${DEBIAN_DIR}
 
     echo "I: Cleanup ${DRIVER_NAME} source"
-#    cd ${CWD}
-#    if [ -e ${DRIVER_FILE} ]; then
-#        rm -f ${DRIVER_FILE}
-#    fi
-#    if [ -d ${DRIVER_DIR} ]; then
-#        rm -rf ${DRIVER_DIR}
-#    fi
-#    if [ -d ${DEBIAN_DIR} ]; then
-#        rm -rf ${DEBIAN_DIR}
-#    fi
+    cd ${CWD}
+    if [ -e ${DRIVER_FILE} ]; then
+        rm -f ${DRIVER_FILE}
+    fi
+    if [ -d ${DRIVER_DIR} ]; then
+        rm -rf ${DRIVER_DIR}
+    fi
+    if [ -d ${DEBIAN_DIR} ]; then
+        rm -rf ${DEBIAN_DIR}
+    fi
 done

--- a/build-linux-firmware.sh
+++ b/build-linux-firmware.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# This script will use "list-required-firmware" to scan the kernel source repository
+# in combination with its configuration file which drivers are compiled. Some of those
+# drivers require proprietary firmware.
+#
+# All selected drivers are then precomfiled "make drivers/foo/bar.i" and we grep for
+# the magic word "UNIQUE_ID_firmware" which identifies firmware files.
+#
+
+CWD=$(pwd)
+LINUX_SRC="linux"
+LINUX_FIRMWARE="linux-firmware"
+result=()
+
+if [ ! -d ${LINUX_SRC} ]; then
+    echo "Kernel source missing"
+    exit 1
+fi
+
+if [ ! -d ${LINUX_FIRMWARE} ]; then
+    echo "Linux firmware repository missing"
+    exit 1
+fi
+
+# Retrieve firmware blobs from source files
+for FILE in $(${CWD}/list-required-firmware.py -k ${LINUX_SRC} -c ${CWD}/x86_64_vyos_defconfig -s drivers/net -s drivers/usb); do
+    cd ${CWD}/${LINUX_SRC}
+    echo "I: determine required firmware blobs for: ${FILE}"
+    make ${FILE/.c/.i} > /dev/null 2>&1
+
+    if [ "$?" == "0" ]; then
+        result+=( $(grep UNIQUE_ID_firmware ${FILE/.c/.i} | cut -d' ' -f12- | xargs printf "%s" | sed -e "s/;/ /") )
+    fi
+done
+
+# Debian package will use the descriptive Git commit as version
+GIT_COMMIT=$(cd ${CWD}/${LINUX_FIRMWARE}; git describe --always)
+VYOS_FIRMWARE_NAME="vyos-linux-firmware"
+VYOS_FIRMWARE_DIR="${CWD}/${VYOS_FIRMWARE_NAME}_${GIT_COMMIT}-0_all"
+if [ -d ${VYOS_FIRMWARE_DIR} ]; then
+    # remove Debian package folder and deb file from previous runs
+    rm -rf ${VYOS_FIRMWARE_DIR}*
+fi
+mkdir -p ${VYOS_FIRMWARE_DIR}
+
+# Copy firmware file from linux firmware repository into
+# assembly folder for the vyos-firmware package
+SED_REPLACE="s@${CWD}/${LINUX_FIRMWARE}/@@"
+for FW in ${result[@]}; do
+    FW_FILE=$(basename $FW)
+
+    res=()
+    for tmp in $(find ${CWD}/linux-firmware -type f -name ${FW_FILE} | sed -e ${SED_REPLACE} )
+    do
+        res+=( "$tmp" )
+    done
+
+    for FILE in ${res[@]}; do
+        FW_DIR="${VYOS_FIRMWARE_DIR}/lib/firmware/$(dirname ${FILE})"
+        mkdir -p ${FW_DIR}
+	echo "I: install firmware: ${FILE}"
+        cp ${CWD}/linux-firmware/${FILE} ${FW_DIR}
+    done
+done
+
+# Describe Debian package
+mkdir ${VYOS_FIRMWARE_DIR}/DEBIAN
+cat << EOF >${VYOS_FIRMWARE_DIR}/DEBIAN/control
+Package: ${VYOS_FIRMWARE_NAME}
+Version: ${GIT_COMMIT}
+Section: kernel
+Priority: extra
+Architecture: all
+Maintainer: VyOS Package Maintainers <maintainers@vyos.net>
+Description: Firmware blobs for use with the Linux kernel
+EOF
+
+# Build Debian package
+fakeroot dpkg-deb --build ${VYOS_FIRMWARE_DIR}

--- a/list-required-firmware.py
+++ b/list-required-firmware.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (C) 2020 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import argparse
+import re
+import os
+import sys
+import glob
+
+def load_config(path):
+    with open(path, 'r') as f:
+        config = f.read()
+    targets = re.findall(r'(.*)=(?:y|m)', config)
+    return targets
+
+def find_subdirs(config, path):
+    try:
+        with open(os.path.join(path, 'Makefile'), 'r') as f:
+            makefile = f.read()
+    except OSError:
+        # No Makefile
+        return []
+
+    dir_stmts = re.findall(r'obj-\$\((.*)\)\s+\+=\s+(.*)(?:\n|$)', makefile)
+    subdirs = []
+
+    for ds in dir_stmts:
+        if args.debug:
+            print("Processing make targets from {0} ({1})".format(ds[1], ds[0]), file=sys.stderr)
+        if ds[0] in config:
+            dirname = os.path.dirname(ds[1])
+            if dirname:
+                subdirs.append(dirname)
+        elif args.debug:
+            print("{0} is disabled in the config, ignoring {1}".format(ds[0], ds[1]), file=sys.stderr)
+
+    return subdirs
+
+
+def find_firmware(file):
+    with open(file, 'r') as f:
+        source = f.read()
+    fws = re.findall(r'MODULE_FIRMWARE\((.*)\)', source)
+    return fws
+
+def walk_dir(config, path):
+    subdirs = find_subdirs(config, path)
+
+    if args.debug:
+        print("Looking for C files in {0}".format(path), file=sys.stderr)
+    c_files = glob.glob("{0}/*.c".format(path))
+
+    for cf in c_files:
+        fws = find_firmware(cf)
+        if fws:
+            print(cf)
+            if args.debug:
+                print("Referenced firmware: {0}".format(fws))
+
+    for d in subdirs:
+        d = os.path.join(path, d)
+        walk_dir(config, d)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--source-dir", action="append", help="Kernel source directory")
+    parser.add_argument("-k", "--kernel-dir", action="store", help="Kernel source directory")
+    parser.add_argument("-c", "--kernel-config", action="store", help="Kernel configuration")
+    parser.add_argument("-d", "--debug", action="store_true", help="Enable Debug output")
+    args = parser.parse_args()
+
+    if args.source_dir and args.kernel_dir and args.kernel_config:
+        config = load_config(args.kernel_config)
+
+        cwd = os.getcwd()
+        os.chdir(f'{cwd}/{args.kernel_dir}')
+        for directory in args.source_dir:
+            walk_dir(config, directory)
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+


### PR DESCRIPTION
In the past when building the VyOS ISO we have simply pulle din the entire
linux-firmware Git repository and just deleted some arbitrary files manually
selected.

Now we run two scripts where the first (list-required-firmware.py) will list
the source files of network drivers we compile for the VyOS kernel. The second
script (build-linux-firmware.sh) will then preprocess (C preprocessor) the
drivers in question and extract the strings of required firmware blobs. Only
the required firmware blobs are then installed into the newly created
vyos-linux-firmware package.
